### PR TITLE
Remove yarn web proxy

### DIFF
--- a/templates/default/yarn-site.xml.erb
+++ b/templates/default/yarn-site.xml.erb
@@ -44,10 +44,6 @@
   </property>
 
   <property>
-    <name>yarn.web-proxy.address</name>
-    <value><%= @rm_private_ip %>:<%= node.apache_hadoop.yarn.ps_port %></value>
-  </property>
-  <property>
     <name>yarn.resourcemanager.webapp.address</name>
     <value>0.0.0.0:8088</value>
     <description>The http address of the RM web application.</description>


### PR DESCRIPTION
Remove the web proxy configuration in yarn-site so that the web proxy is run by the resource manager.