### PR TITLE
Reverting to master branch as 7_5 is merged.

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -3,7 +3,7 @@ source 'https://supermarket.chef.io'
 metadata
 
 cookbook 'java', '~> 1.39.0'
-cookbook 'ndb', github: "hopshadoop/ndb-chef", branch: "7_5"
+cookbook 'ndb', github: "hopshadoop/ndb-chef", branch: "master"
 cookbook 'kagent', github: "karamelchef/kagent-chef", branch: "master"
 cookbook 'apache_hadoop', github: "hopshadoop/apache-hadoop-chef", branch: "master"
 


### PR DESCRIPTION
Branch 7_5 is merged and does not exist. Because of that there is a berks failure in the cookbook while vendor.