### PR TITLE
container-metrics.period-ms added

### DIFF
--- a/templates/default/yarn-site.xml.erb
+++ b/templates/default/yarn-site.xml.erb
@@ -369,4 +369,11 @@
     <value>0.1</value>
 </property>
   
+<!-- container monitoring and metrics period -->
+  <property>
+    <name>yarn.nodemanager.container-metrics.period-ms</name>
+    <value>2000</value>
+    <description>Container metrics flush period in ms. Set to -1 for flush on completion.</description>
+  </property>
+  
 </configuration>


### PR DESCRIPTION
yarn.nodemanager.container-metrics.period-ms config parameter is not present in the yarn-site.xml file. This will allow to log more metrics to the influxdb