### PR TITLE
HOPSWORKS-175

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,6 +3,7 @@ include_attribute "ndb"
 default["hops"]["version"]                     = "2.7.3"
 
 default["hops"]["hdfs"]["user"]                = node["install"]["user"].empty? ? "hdfs" : node["install"]["user"]
+default["hops"]["hdfs"]["superuser_group"]     = "hdfsadmin"
 default["hops"]["group"]                       = node["install"]["user"].empty? ? "hadoop" : node["install"]["user"]
 default["hops"]["yarn"]["user"]                = node["install"]["user"].empty? ? "yarn" : node["install"]["user"]
 default["hops"]["mr"]["user"]                  = node["install"]["user"].empty? ? "mapred" : node["install"]["user"]

--- a/metadata.rb
+++ b/metadata.rb
@@ -383,3 +383,7 @@ attribute "hops/util_version",
 attribute "hops/cgroups",
           :description => "'true' to enable cgroups, else (default) 'false'",
           :type => "string"
+
+attribute "livy/user",
+          :description => "Livy user that will be a proxy user",
+          :type => "string"

--- a/metadata.rb
+++ b/metadata.rb
@@ -232,6 +232,10 @@ attribute "hops/hdfs/user",
           :description => "Username to run hdfs as",
           :type => 'string'
 
+attribute "hops/hdfs/superuser_group",
+          :description => "Group for users with hdfs superuser privileges",
+          :type => 'string'
+
 attribute "hops/hdfs/blocksize",
           :description => "HDFS Blocksize (128k, 512m, 1g, etc). Default 128m.",
           :type => 'string'

--- a/providers/ndb.rb
+++ b/providers/ndb.rb
@@ -12,7 +12,7 @@ new_resource.updated_by_last_action(false)
   end
 
   bash "mysql-install-hops" do
-    user node.ndb.user
+    user "root"
     code <<-EOF
     set -e
     #{node.ndb.scripts_dir}/mysql-client.sh -e \"CREATE DATABASE IF NOT EXISTS #{node.hops.db} CHARACTER SET latin1\"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -41,6 +41,11 @@ if node.attribute?("hopsworks")
   hopsworksNodes = node[:hopsworks][:default][:private_ips].join(",")
 end
 
+livyUser = "livy"
+if node.attribute?("livy")
+  livyUser = node[:livy][:user]
+end
+
 
 # If the user specified "gpu_enabled" to be true in a cluster definition, then accept that.
 # Else, if cuda/accept_nvidia_download_terms is set to true, then make gpu_enabled true.
@@ -81,6 +86,7 @@ template "#{node.hops.home}/etc/hadoop/core-site.xml" do
   variables({
               :firstNN => firstNN,
               :hopsworks => hopsworksNodes,
+              :livyUser => livyUser,              
               :allNNs => allNNIps,
               :kstore => "#{node.kagent.keystore_dir}/#{node['hostname']}__kstore.jks",
               :tstore => "#{node.kagent.keystore_dir}/#{node['hostname']}__tstore.jks",

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -43,12 +43,16 @@ end
 
 livyUser = "livy"
 if node.attribute?("livy")
-  livyUser = node[:livy][:user]
+  if node['livy'].attribute?("user")
+    livyUser = node[:livy][:user]
+  end
 end
 
 hiveUser = "hive"
 if node.attribute?("hive2")
-  hiveUser = node[:hive2][:user]
+  if node['hive2'].attribute?("user")
+    hiveUser = node[:hive2][:user]
+  end
 end
 
 

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -231,7 +231,7 @@ end
 directory node.hops.data_dir do
   owner node.hops.hdfs.user
   group node.hops.group
-  mode "0775"
+  mode "0770"
   recursive true
   action :create
 end
@@ -255,7 +255,7 @@ else
   directory node.hops.dn.data_dir do
     owner node.hops.hdfs.user
     group node.hops.group
-    mode "0774"
+    mode "0770"
     recursive true    
     action :create
   end
@@ -264,7 +264,7 @@ end
 directory node.hops.nn.name_dir do
   owner node.hops.hdfs.user
   group node.hops.group
-  mode "0774"
+  mode "0770"
   recursive true  
   action :create
 end
@@ -313,6 +313,7 @@ bash 'extract-hadoop' do
         # chown -L : traverse symbolic links
         chown -RL #{node.hops.hdfs.user}:#{node.hops.group} #{node.hops.home}
         chown -RL #{node.hops.hdfs.user}:#{node.hops.group} #{node.hops.base_dir}
+        chmod 770 #{node.hops.home}
         # remove the config files that we would otherwise overwrite
         rm -f #{node.hops.home}/etc/hadoop/yarn-site.xml
 	rm -f #{node.hops.home}/etc/hadoop/container-executor.cfg
@@ -364,14 +365,14 @@ end
  directory node.hops.logs_dir do
    owner node.hops.hdfs.user
    group node.hops.group
-   mode "0775"
+   mode "0770"
    action :create
  end
 
  directory node.hops.tmp_dir do
    owner node.hops.hdfs.user
    group node.hops.group
-   mode "1777"
+   mode "1770"
    action :create
  end
 
@@ -464,7 +465,7 @@ template "#{node.hops.home}/etc/hadoop/mapred-site.xml" do
   source "mapred-site.xml.erb"
   owner node.hops.mr.user
   group node.hops.group
-  mode "755"
+  mode "750"
   variables({
               :rm_private_ip => rm_private_ip
             })

--- a/recipes/ndb.rb
+++ b/recipes/ndb.rb
@@ -6,9 +6,8 @@ my_ip = my_private_ip()
 directory "#{node.hops.dir}/ndb-hops-#{node.hops.version}-#{node.ndb.version}" do
   owner node.hops.hdfs.user
   group node.hops.group
-  mode "755"
+  mode "750"
   action :create
-  recursive true
 end
 
 link "#{node.hops.dir}/ndb-hops" do
@@ -78,7 +77,7 @@ if node['hops'].attribute?('nn') == true && node['hops']['nn'].attribute?(:priva
       source "#{script}.erb"
       owner node.hops.hdfs.user
       group node.hops.group
-      mode 0775
+      mode 0770
     end
   end 
 
@@ -89,7 +88,7 @@ if node['hops'].attribute?('nn') == true && node['hops']['nn'].attribute?(:priva
     source "format-nn.sh.erb"
     owner node.hops.hdfs.user
     group node.hops.group
-    mode 0775
+    mode 0770
     variables({
                 :format_opts => node.hops.nn.format_options
               })

--- a/recipes/nn.rb
+++ b/recipes/nn.rb
@@ -32,6 +32,22 @@ if node.hops.rpc.ssl_enabled.eql? "true"
   end
 end
 
+
+livyUser = "livy"
+if node.attribute?("livy")
+  if node['livy'].attribute?("user")
+    livyUser = node[:livy][:user]
+  end
+end
+
+hiveUser = "hive"
+if node.attribute?("hive2")
+  if node['hive2'].attribute?("user")
+    hiveUser = node[:hive2][:user]
+  end
+end
+
+
 myNN = "#{my_ip}:#{nnPort}"
 template "#{node.hops.home}/etc/hadoop/core-site.xml" do 
   source "core-site.xml.erb"
@@ -42,6 +58,8 @@ template "#{node.hops.home}/etc/hadoop/core-site.xml" do
               :firstNN => "hdfs://" + myNN,
               :hopsworks => hopsworksNodes,
               :allNNs => myNN,
+              :livyUser => livyUser,
+              :hiveUser => hiveUser,              
               :kstore => "#{node.kagent.keystore_dir}/#{node['hostname']}__kstore.jks",
               :tstore => "#{node.kagent.keystore_dir}/#{node['hostname']}__tstore.jks",
               :rpcSocketFactory => rpcSocketFactory,

--- a/templates/default/core-site.xml.erb
+++ b/templates/default/core-site.xml.erb
@@ -5,46 +5,46 @@
 
 <configuration>
 
-<!-- In: conf/core-site.xml -->
-<property>
-  <name>hadoop.tmp.dir</name>
-  <value><%= node.hops.tmp_dir %></value>
-  <description>A base for other temporary directories.</description>
-</property>
+  <!-- In: conf/core-site.xml -->
+  <property>
+    <name>hadoop.tmp.dir</name>
+    <value><%= node.hops.tmp_dir %></value>
+    <description>A base for other temporary directories.</description>
+  </property>
 
-<!--
-<property>
-  <name>io.file.buffer.size</name>
-  <value><%= node.hops.io_buffer_sz %></value>
-  <description>Size of read/write buffer used in SequenceFiles.</description>
-</property>
--->
+  <!--
+      <property>
+      <name>io.file.buffer.size</name>
+      <value><%= node.hops.io_buffer_sz %></value>
+      <description>Size of read/write buffer used in SequenceFiles.</description>
+      </property>
+  -->
 
-<property>
-  <name>dfs.namenodes.rpc.addresses</name>
-  <value><%= @allNNs %></value>  
-  <description>HopsFS-specific list of comma-separated host:port pairs for NameNodes.</description>
-</property>
+  <property>
+    <name>dfs.namenodes.rpc.addresses</name>
+    <value><%= @allNNs %></value>  
+    <description>HopsFS-specific list of comma-separated host:port pairs for NameNodes.</description>
+  </property>
 
-<property>
-  <name>ipc.client.connect.max.retries</name>
-  <value><%= node.hops.max_retries %></value>
-  <description>If a HDFS client has a communication problem with a NameNode, retry the connection the number of times specified here.</description>
-</property>
-
-
-<property>
-  <name>dfs.storage.driver.configfile</name>
-  <value>ndb.props</value>
-  <description>
-  </description>
-</property>
+  <property>
+    <name>ipc.client.connect.max.retries</name>
+    <value><%= node.hops.max_retries %></value>
+    <description>If a HDFS client has a communication problem with a NameNode, retry the connection the number of times specified here.</description>
+  </property>
 
 
-<!--
+  <property>
+    <name>dfs.storage.driver.configfile</name>
+    <value>ndb.props</value>
+    <description>
+    </description>
+  </property>
+
+
+
   <property>
     <name>hadoop.proxyuser.<%= node.hops.hdfs.user %>.hosts</name>
-    <value>@hopsworks</value>
+    <value>*</value>
   </property>
   <property>
     <name>hadoop.proxyuser.<%= node.hops.hdfs.user %>.groups</name>
@@ -53,193 +53,183 @@
 
   <property>
     <name>hadoop.proxyuser.<%= node.hops.yarn.user %>.hosts</name>
-    <value>@hopsworks</value>
+    <value>*</value>
   </property>
   <property>
     <name>hadoop.proxyuser.<%= node.hops.yarn.user %>.groups</name>
     <value>*</value>
   </property>
--->
+  <property>
+    <name>hadoop.proxyuser.<%= @livyUser %>.hosts</name>
+    <value>*</value>
+  </property>
+  <property>
+    <name>hadoop.proxyuser.<%= @livyUser %>.groups</name>
+    <value>*</value>
+  </property>
 
-<property>
-  <name>hadoop.proxyuser.<%= node.hops.yarn.user %>.hosts</name>
-  <value>*</value>
-</property>
-<property>
-  <name>hadoop.proxyuser.<%= node.hops.yarn.user %>.groups</name>
-  <value>*</value>
-</property>
-<property>
-  <name>hadoop.proxyuser.jupyter.hosts</name>
-  <value>*</value>
-</property>
-<property>
-  <name>hadoop.proxyuser.jupyter.groups</name>
-  <value>*</value>
-</property>
+  <property>
+    <name>dfs.leader.check.interval</name>
+    <value>2000</value>
+    <description>Interval between the NameNode or ResourceMgr running the leader election protocol. </description>
+  </property>
 
-<property>
-  <name>dfs.leader.check.interval</name>
-  <value>2000</value>
-  <description>Interval between the NameNode or ResourceMgr running the leader election protocol. </description>
-</property>
+  <property>
+    <name>dfs.leader.missed.hb</name>
+    <value>2</value>
+    <description></description>
+  </property>
 
-<property>
-  <name>dfs.leader.missed.hb</name>
-  <value>2</value>
-  <description></description>
-</property>
-
-<property>
-  <name>dfs.leader.tp.increment</name>
-  <value>100</value>
-  <description></description>
-</property>
+  <property>
+    <name>dfs.leader.tp.increment</name>
+    <value>100</value>
+    <description></description>
+  </property>
 
   
-<!-- SSL -->
-<property>
+  <!-- SSL -->
+  <property>
     <name>hadoop.ssl.require.client.cert</name>
     <value>false</value>
-</property>
-<property>
+  </property>
+  <property>
     <name>hadoop.ssl.hostname.verifier</name>
     <value>DEFAULT</value>
     <description></description>
-</property>
-<property>
+  </property>
+  <property>
     <name>hadoop.ssl.keystores.factory.class</name>
     <value>org.apache.hadoop.security.ssl.FileBasedKeyStoresFactory</value>
     <description></description>
-</property>
-<property>
+  </property>
+  <property>
     <name>hadoop.ssl.server.conf</name>
     <value>ssl-server.xml</value>
     <description></description>
-</property>
-<property>
+  </property>
+  <property>
     <name>hadoop.ssl.client.conf</name>
     <value>ssl-client.xml</value>
     <description></description>
-</property>
+  </property>
 
 
- <property> 
-   <name>hadoop.proxyuser.yarn.hosts</name>
-   <value>*</value>
- </property>
- 
- <property>
-   <name>hadoop.proxyuser.yarn.groups</name>
-   <value>*</value>
- </property>
-
-<property>
-  <name>hadoop.proxyuser.hive.hosts</name>
-  <value>*</value>
-</property>
-<property>
-  <name>hadoop.proxyuser.hive.groups</name>
-  <value>*</value>
-</property>
-
-  
- <property>
-  <name>fs.defaultFS</name>
-  <value><%= @firstNN %></value>
- </property>
-
- <property>
-   <name>fs.trash.interval</name>
-   <value><%= node.hops.trash.interval %></value>
- </property>
-
- <property>
-   <name>fs.trash.checkpoint.interval</name>
-   <value><%= node.hops.trash.checkpoint.interval %></value>
- </property>
-
- <property>
-   <name>hadoop.security.groups.cache.secs</name>
-   <value>1</value>
- </property>
-
- <property>
-   <name>ipc.server.read.threadpool.size</name>
-   <value><%= node.hops.server.threadpool %></value>
- </property>
- 
- <!-- RPC TLS support -->
- <property>
-   <name>ipc.server.ssl.enabled</name>
-   <value><%= node.hops.rpc.ssl_enabled %></value>
- </property>
-
- <property>
-   <name>hadoop.ssl.hostname.verifier</name>
-   <value><%= node.hops.hadoop.ssl.hostname.verifier %></value>
- </property>
-
- <property>
-   <name>hadoop.rpc.socket.factory.class.default</name>
-   <value><%= @rpcSocketFactory %></value>
- </property>
-
- <property>
-   <name>hadoop.ssl.enabled.protocols</name>
-   <value><%= node.hops.hadoop.ssl.enabled.protocols %></value>
- </property>
-
- <!--
-     Directory where service certificates exist. It is used by
-     HopsSSLSocketFactory for superuser.
-     Default: /srv/hops/kagent-certs/keystores
- -->
- <property>
-   <name>hops.service.certificates.directory</name>
-   <value><%= node.kagent.keystore_dir %></value>
- </property>
-
- <!--
-     Directory where users' certificates are materialized from
-     Hopsworks. It is used by HopsSSLSocketFactory to setup the
-     correct crypto material for non-superuser.
-     Default: /srv/hops/domains/domain1/kafkacerts
- -->
-  <property>
-   <name>client.materialize.directory</name>
-   <value><%= node.certs.dir %>/transient</value>
+  <property> 
+    <name>hadoop.proxyuser.yarn.hosts</name>
+    <value>*</value>
   </property>
   
- <!-- TLS client configuration -->
- <property>
-   <name>client.rpc.ssl.keystore.filepath</name>
-   <value><%= @kstore %></value>
- </property>
+  <property>
+    <name>hadoop.proxyuser.yarn.groups</name>
+    <value>*</value>
+  </property>
 
- <property>
-   <name>client.rpc.ssl.keystore.password</name>
-   <value><%= node.hops.ssl.server.keystore.password %></value>
- </property>
+  <property>
+    <name>hadoop.proxyuser.hive.hosts</name>
+    <value>*</value>
+  </property>
+  <property>
+    <name>hadoop.proxyuser.hive.groups</name>
+    <value>*</value>
+  </property>
 
- <property>
-   <name>client.rpc.ssl.keypassword</name>
-   <value><%= node.hops.ssl.server.keystore.keypassword %></value>
- </property>
+  
+  <property>
+    <name>fs.defaultFS</name>
+    <value><%= @firstNN %></value>
+  </property>
 
- <property>
-   <name>client.rpc.ssl.truststore.filepath</name>
-   <value><%= @tstore %></value>
- </property>
+  <property>
+    <name>fs.trash.interval</name>
+    <value><%= node.hops.trash.interval %></value>
+  </property>
 
- <property>
-   <name>client.rpc.ssl.truststore.password</name>
-   <value><%= node.hops.ssl.server.truststore.password %></value>
- </property>
- 
- <property>
-   <name>client.rpc.ssl.enabled.protocol</name>
-   <value>TLSv1.2</value>
- </property>
- 
+  <property>
+    <name>fs.trash.checkpoint.interval</name>
+    <value><%= node.hops.trash.checkpoint.interval %></value>
+  </property>
+
+  <property>
+    <name>hadoop.security.groups.cache.secs</name>
+    <value>1</value>
+  </property>
+
+  <property>
+    <name>ipc.server.read.threadpool.size</name>
+    <value><%= node.hops.server.threadpool %></value>
+  </property>
+  
+  <!-- RPC TLS support -->
+  <property>
+    <name>ipc.server.ssl.enabled</name>
+    <value><%= node.hops.rpc.ssl_enabled %></value>
+  </property>
+
+  <property>
+    <name>hadoop.ssl.hostname.verifier</name>
+    <value><%= node.hops.hadoop.ssl.hostname.verifier %></value>
+  </property>
+
+  <property>
+    <name>hadoop.rpc.socket.factory.class.default</name>
+    <value><%= @rpcSocketFactory %></value>
+  </property>
+
+  <property>
+    <name>hadoop.ssl.enabled.protocols</name>
+    <value><%= node.hops.hadoop.ssl.enabled.protocols %></value>
+  </property>
+
+  <!--
+      Directory where service certificates exist. It is used by
+      HopsSSLSocketFactory for superuser.
+      Default: /srv/hops/kagent-certs/keystores
+  -->
+  <property>
+    <name>hops.service.certificates.directory</name>
+    <value><%= node.kagent.keystore_dir %></value>
+  </property>
+
+  <!--
+      Directory where users' certificates are materialized from
+      Hopsworks. It is used by HopsSSLSocketFactory to setup the
+      correct crypto material for non-superuser.
+      Default: /srv/hops/domains/domain1/kafkacerts
+  -->
+  <property>
+    <name>client.materialize.directory</name>
+    <value><%= node.certs.dir %>/transient</value>
+  </property>
+  
+  <!-- TLS client configuration -->
+  <property>
+    <name>client.rpc.ssl.keystore.filepath</name>
+    <value><%= @kstore %></value>
+  </property>
+
+  <property>
+    <name>client.rpc.ssl.keystore.password</name>
+    <value><%= node.hops.ssl.server.keystore.password %></value>
+  </property>
+
+  <property>
+    <name>client.rpc.ssl.keypassword</name>
+    <value><%= node.hops.ssl.server.keystore.keypassword %></value>
+  </property>
+
+  <property>
+    <name>client.rpc.ssl.truststore.filepath</name>
+    <value><%= @tstore %></value>
+  </property>
+
+  <property>
+    <name>client.rpc.ssl.truststore.password</name>
+    <value><%= node.hops.ssl.server.truststore.password %></value>
+  </property>
+  
+  <property>
+    <name>client.rpc.ssl.enabled.protocol</name>
+    <value>TLSv1.2</value>
+  </property>
+  
 </configuration>

--- a/templates/default/hdfs-site.xml.erb
+++ b/templates/default/hdfs-site.xml.erb
@@ -263,7 +263,15 @@
      <name>dfs.webhdfs.enabled</name>
      <value>true</value>
   </property>
-  
+
+
+  <property>
+    <name>dfs.permissions.superusergroup</name>
+    <value>hdfsadmin</value>    
+    <description></description>
+  </property>
+
+
 <!--
   <property>
     <name>dfs.namenode.datanode.registration.ip-hostname-check</name>

--- a/templates/default/hdfs-site.xml.erb
+++ b/templates/default/hdfs-site.xml.erb
@@ -267,8 +267,8 @@
 
   <property>
     <name>dfs.permissions.superusergroup</name>
-    <value>hdfsadmin</value>    
-    <description></description>
+    <value>hdfs</value>    
+    <description>The group for hdfs superusers</description>
   </property>
 
 


### PR DESCRIPTION
Create a hdfs supergroup, and add glassfish and hdfs users to it. Glassfish needs superuser permissions to perform log aggregation in Hopsworks. Livy and Hive users need to be able to do secure impersonation.