### PR TITLE
HOPSWORKS-232

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -138,7 +138,7 @@ end
 
 group node['kagent']['certs_group'] do
   action :modify
-  members ["#{node['hops']['hdfs']['user']}", "#{node['hops']['yarn']['user']}"]
+  members ["#{node['hops']['hdfs']['user']}", "#{node['hops']['yarn']['user']}", "#{node['hops']['rm']['user']}"]
   append true
 end
 

--- a/recipes/nn.rb
+++ b/recipes/nn.rb
@@ -38,6 +38,7 @@ template "#{node['hops']['home']}/etc/hadoop/core-site.xml" do
               :hopsworksUser => node['hopsworks']['user'],
               :livyUser => node['livy']['user'],
               :hiveUser => node['hive2']['user'],
+              :jupyterUser => node['jupyter']['user'],
               :allNNs => myNN,
               :rpcSocketFactory => node['hops']['hadoop']['rpc']['socket']['factory'],
               :hopsworks_endpoint => hopsworks_endpoint

--- a/templates/default/core-site.xml.erb
+++ b/templates/default/core-site.xml.erb
@@ -89,6 +89,14 @@
     <name>hadoop.proxyuser.<%= @hiveUser %>.groups</name>
     <value>*</value>
   </property>
+    <property>
+    <name>hadoop.proxyuser.<%= @jupyterUser %>.hosts</name>
+    <value>*</value>
+  </property>
+  <property>
+    <name>hadoop.proxyuser.<%= @jupyterUser %>.groups</name>
+    <value>*</value>
+  </property>
 
   <property>
     <name>dfs.leader.check.interval</name>


### PR DESCRIPTION
* Add yarn, rmyarn and hdfs users to certificates group and remove acl
* Put back acl for hdfs user on keystores, needed during deployment
* Fix syntax error
* Add jupyter user to super proxyusers

https://hopshadoop.atlassian.net/browse/HOPSWORKS-232