### PR TITLE
[HOPSWORKS-679]  Refine python environments

### DIFF
--- a/Karamelfile
+++ b/Karamelfile
@@ -1,6 +1,7 @@
 dependencies:
   - recipe: hops::install
     global:
+      - conda::install
       - kagent::install
   - recipe: hops::ndb
     global:

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -12,13 +12,6 @@ end
 require 'resolv'
 
 
-group node['hops']['group'] do
-  action :modify
-  members ["#{node['conda']['user']}"]
-  append true
-end
-
-
 nnPort=node['hops']['nn']['port']
 hops_group=node['hops']['group']
 my_ip = my_private_ip()


### PR DESCRIPTION
…[HOPSWORKS-679]  Make install dependent on conda::install, conda user should be added to hadoop group before the default phase

[HOPSWORKS-679]  Fix cookbooks order

https://logicalclocks.atlassian.net/browse/HOPSWORKS-679